### PR TITLE
Added ability to integrate live incoming camera data

### DIFF
--- a/src/open3d_interface/yak/__init__.py
+++ b/src/open3d_interface/yak/__init__.py
@@ -54,9 +54,14 @@ rgb_poses = []
 prev_pose_rot = np.array([1.0, 0.0, 0.0, 0.0])
 prev_pose_tran = np.array([0.0, 0.0, 0.0])
 
+tsdf_integration_data = deque()
+integration_done = True
+live_integration = False
+
 record = False
 frame_count = 0
 processed_frame_count = 0
+
 
 def archiveData(path_output):
   global depth_images, color_images, rgb_poses, intrinsics
@@ -81,7 +86,7 @@ def startYakReconstructionCallback(req):
   global record, frame_count, processed_frame_count, relative_frame, tracking_frame
   global color_images, depth_images, rgb_poses, sensor_data, tsdf_volume
   global depth_scale, depth_trunc, convert_rgb_to_intensity
-  global prev_pose_rot, prev_pose_tran, translation_distance, rotational_distance
+  global prev_pose_rot, prev_pose_tran, translation_distance, rotational_distance, live_integration
 
   rospy.loginfo(rospy.get_caller_id() + ": Start Reconstruction")
 
@@ -89,6 +94,7 @@ def startYakReconstructionCallback(req):
   depth_images.clear()
   rgb_poses.clear()
   sensor_data.clear()
+  tsdf_integration_data.clear()
   prev_pose_rot = np.array([1.0, 0.0, 0.0, 0.0])
   prev_pose_tran = np.array([0.0, 0.0, 0.0])
 
@@ -108,23 +114,26 @@ def startYakReconstructionCallback(req):
   translation_distance = req.translation_distance
   rotational_distance = req.rotational_distance
 
+  live_integration = req.live
   record = True
   return StartYakReconstructionResponse(True)
 
 def stopYakReconstructionCallback(req):
   global record, tsdf_volume, depth_images, color_images, rgb_poses, depth_scale, depth_trunc, intrinsics
+  global integration_done
 
   rospy.loginfo(rospy.get_caller_id() + ": Stop Reconstruction")
   record = False
 
-  for s in range(len(color_images)):
-    rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(color_images[s], depth_images[s], depth_scale, depth_trunc, False)
-    tsdf_volume.integrate(rgbd, intrinsics, np.linalg.inv(rgb_poses[s]))
+  while not integration_done:
+    rospy.sleep(1.0)
 
+  print("Generating mesh")
   mesh = tsdf_volume.extract_triangle_mesh()
   mesh.compute_vertex_normals()
   mesh_filepath = join(req.results_directory, "integrated.ply")
   o3d.io.write_triangle_mesh(mesh_filepath, mesh, False, True)
+  print("Mesh Generated")
 
   if (req.archive_directory != ""):
     rospy.loginfo(rospy.get_caller_id() + ": Archiving data to " + req.archive_directory)
@@ -138,10 +147,12 @@ def stopYakReconstructionCallback(req):
 def cameraCallback(depth_image_msg, rgb_image_msg):
   global frame_count, processed_frame_count, record, tracking_frame, relative_frame, tf_listener
   global color_images, depth_images, rgb_poses, intrinsics, prev_pose_rot, prev_pose_tran
+  global tsdf_integration_data, live_integration, integration_done
 
   if record:
     try:
         # Convert your ROS Image message to OpenCV2
+        # TODO: Generalize image type
         cv2_depth_img = bridge.imgmsg_to_cv2(depth_image_msg, "16UC1")
         cv2_rgb_img = bridge.imgmsg_to_cv2(rgb_image_msg, "bgr8")
     except CvBridgeError:
@@ -162,6 +173,7 @@ def cameraCallback(depth_image_msg, rgb_image_msg):
           tran_dist = np.linalg.norm(rgb_t - prev_pose_tran)
           rot_dist = Quaternion.absolute_distance(Quaternion(prev_pose_rot), Quaternion(rgb_r))
 
+          # TODO: Testing if this is a good practice, min jump to accept data
           if (tran_dist > translation_distance) or (rot_dist > rotational_distance):
             prev_pose_tran = rgb_t
             prev_pose_rot = rgb_r
@@ -173,11 +185,32 @@ def cameraCallback(depth_image_msg, rgb_image_msg):
             depth_images.append(data[0])
             color_images.append(data[1])
             rgb_poses.append(rgb_pose)
+            if live_integration:
+              integration_done = False
+              rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(data[1], data[0], depth_scale, depth_trunc, False)
+              tsdf_volume.integrate(rgbd, intrinsics, np.linalg.inv(rgb_pose))
+              integration_done = True
+            else:
+              tsdf_integration_data.append([data[0], data[1], rgb_pose])
 
             processed_frame_count += 1
 
         frame_count += 1
 
+def timerReconstruction(timer):
+  global depth_scale, depth_trunc, convert_rgb_to_intensity
+  global tsdf_integration_data, integration_done
+  integrating_queue = False
+  while len(tsdf_integration_data) > 0:
+      integrating_queue = True
+      print("Integrating,", len(tsdf_integration_data), "images left to integrate")
+      integration_done = False
+      data = tsdf_integration_data.popleft()
+      rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(data[1], data[0], depth_scale, depth_trunc, False)
+      tsdf_volume.integrate(rgbd, intrinsics, np.linalg.inv(data[2]))
+  if integrating_queue:
+    print("Integration done")
+    integration_done = True
 
 def main():
   global camera_info_topic, tf_listener, tracking_frame, world_frame
@@ -203,6 +236,8 @@ def main():
   color_sub = Subscriber(color_image_topic, Image)
   tss = ApproximateTimeSynchronizer([depth_sub, color_sub], cache_count, slop, allow_headerless)
   tss.registerCallback(cameraCallback)
+
+  rospy.Timer(rospy.Duration(0.5), timerReconstruction)
 
   start_server = rospy.Service('start_reconstruction', StartYakReconstruction, startYakReconstructionCallback)
   stop_server = rospy.Service('stop_reconstruction', StopYakReconstruction, stopYakReconstructionCallback)

--- a/srv/StartYakReconstruction.srv
+++ b/srv/StartYakReconstruction.srv
@@ -3,6 +3,7 @@ string tracking_frame # The frame to be tracked
 string relative_frame # The frame to recored the tracked_frame pose relative to
 float32 translation_distance # The minimum translation distance in meters required before recording another image
 float32 rotational_distance # The minimum rotational distance required before recording another image
+bool live # Whether or not to do integration live, may cause loss of some data
 
 open3d_interface/TSDFVolumeParams tsdf_params
 open3d_interface/RGBDImageParams rgbd_params


### PR DESCRIPTION
This change allows you to start integrating the data into the tsdf model while it is incoming by default. The additional parameter _live_ in the request will integrate the images as they come in, at the expense of potentially losing some images. With _live_ set to false the integration still begins immediately upon receiving images, but it doesn't drop any images for a tradeoff of not being ready immediately on the stop reconstruction call.