### PR TITLE
Make some changes to allow running multiple nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(catkin REQUIRED COMPONENTS
   message_generation
   std_msgs
+  visualization_msgs
 )
 
 catkin_python_setup()
@@ -36,11 +37,13 @@ add_service_files(
 generate_messages(
   DEPENDENCIES
     std_msgs
+    visualization_msgs
 )
 
 catkin_package(
   CATKIN_DEPENDS
     message_runtime
+    visualization_msgs
     std_msgs)
 
 include_directories(include ${catkin_INCLUDE_DIRS})

--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,12 @@
   <build_depend>rospy</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>visualization_msgs</build_depend>
 
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>roslaunch</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
 
 </package>

--- a/src/open3d_interface/general_recorder/__init__.py
+++ b/src/open3d_interface/general_recorder/__init__.py
@@ -137,7 +137,7 @@ def main():
   tss = ApproximateTimeSynchronizer([depth_sub, rgb_sub], cache_count, slop, allow_headerless)
   tss.registerCallback(cameraCallback)
 
-  start_server = rospy.Service('start_recording', StartRecording, startRecordingCallback)
-  stop_server = rospy.Service('stop_recording', StopRecording, stopRecordingCallback)
+  start_server = rospy.Service('~start_recording', StartRecording, startRecordingCallback)
+  stop_server = rospy.Service('~stop_recording', StopRecording, stopRecordingCallback)
 
   rospy.spin()

--- a/src/open3d_interface/reconstruction/__init__.py
+++ b/src/open3d_interface/reconstruction/__init__.py
@@ -131,7 +131,7 @@ def runTSDFReconstructionCallback(req):
 def runReconstructionSystemCallback(req):
   rospy.loginfo(rospy.get_caller_id() + "Reconstructing Surface")
 
-  if not req.make and not req.register and not req.refine and not req.integrate:
+  if not req.make and not req.register_fragments and not req.refine and not req.integrate:
      return ReconstructSurfaceResponse(False)
 
   config = {}
@@ -168,7 +168,7 @@ def runReconstructionSystemCallback(req):
       import open3d_interface.reconstruction.make_fragments as make_fragments
       make_fragments.run(config)
       times[0] = time.time() - start_time
-  if req.register:
+  if req.register_fragments:
       start_time = time.time()
       import open3d_interface.reconstruction.register_fragments as register_fragments
       register_fragments.run(config)

--- a/src/open3d_interface/reconstruction/__init__.py
+++ b/src/open3d_interface/reconstruction/__init__.py
@@ -199,7 +199,7 @@ def runReconstructionSystemCallback(req):
 def main():
   rospy.init_node('open3d_reconstruction', anonymous=True)
 
-  reconstruction_system_server = rospy.Service('run_reconstruction_system', RunReconstructionSystem, runReconstructionSystemCallback)
-  tsdf_reconstruction_server = rospy.Service('run_tsdf_reconstruction', RunTSDFReconstruction, runTSDFReconstructionCallback)
+  reconstruction_system_server = rospy.Service('~run_reconstruction_system', RunReconstructionSystem, runReconstructionSystemCallback)
+  tsdf_reconstruction_server = rospy.Service('~run_tsdf_reconstruction', RunTSDFReconstruction, runTSDFReconstructionCallback)
 
   rospy.spin()

--- a/src/open3d_interface/reconstruction/integrate_scene.py
+++ b/src/open3d_interface/reconstruction/integrate_scene.py
@@ -39,12 +39,15 @@ def scalable_integrate_rgb_frames(path_dataset, intrinsic, config):
                 "Fragment %03d / %03d :: integrate rgbd frame %d (%d of %d)." %
                 (fragment_id, n_fragments - 1, frame_id_abs, frame_id + 1,
                  len(pose_graph_rgbd.nodes)))
-            rgbd = read_rgbd_image(color_files[frame_id_abs],
-                                   depth_files[frame_id_abs], False, config)
-            pose = np.dot(pose_graph_fragment.nodes[fragment_id].pose,
-                          pose_graph_rgbd.nodes[frame_id].pose)
-            volume.integrate(rgbd, intrinsic, np.linalg.inv(pose))
-            poses.append(pose)
+            try:
+                rgbd = read_rgbd_image(color_files[frame_id_abs],
+                                       depth_files[frame_id_abs], False, config)
+                pose = np.dot(pose_graph_fragment.nodes[fragment_id].pose,
+                              pose_graph_rgbd.nodes[frame_id].pose)
+                volume.integrate(rgbd, intrinsic, np.linalg.inv(pose))
+                poses.append(pose)
+            except:
+                print("Failed to integrate frame")
 
     mesh = volume.extract_triangle_mesh()
     mesh.compute_vertex_normals()

--- a/src/open3d_interface/reconstruction/make_fragments.py
+++ b/src/open3d_interface/reconstruction/make_fragments.py
@@ -122,14 +122,17 @@ def integrate_rgb_frames_for_fragment(color_files, depth_files, fragment_id,
         sdf_trunc=0.04,
         color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8)
     for i in range(len(pose_graph.nodes)):
-        i_abs = fragment_id * config['n_frames_per_fragment'] + i
-        print(
-            "Fragment %03d / %03d :: integrate rgbd frame %d (%d of %d)." %
-            (fragment_id, n_fragments - 1, i_abs, i + 1, len(pose_graph.nodes)))
-        rgbd = read_rgbd_image(color_files[i_abs], depth_files[i_abs], False,
-                               config)
-        pose = pose_graph.nodes[i].pose
-        volume.integrate(rgbd, intrinsic, np.linalg.inv(pose))
+        try:
+            i_abs = fragment_id * config['n_frames_per_fragment'] + i
+            print(
+                "Fragment %03d / %03d :: integrate rgbd frame %d (%d of %d)." %
+                (fragment_id, n_fragments - 1, i_abs, i + 1, len(pose_graph.nodes)))
+            rgbd = read_rgbd_image(color_files[i_abs], depth_files[i_abs], False,
+                                   config)
+            pose = pose_graph.nodes[i].pose
+            volume.integrate(rgbd, intrinsic, np.linalg.inv(pose))
+        except:
+            print("Integrating image failed")
     mesh = volume.extract_triangle_mesh()
     mesh.compute_vertex_normals()
     return mesh

--- a/src/open3d_interface/yak/__init__.py
+++ b/src/open3d_interface/yak/__init__.py
@@ -135,12 +135,15 @@ def stopYakReconstructionCallback(req):
   print("Generating mesh")
   mesh = tsdf_volume.extract_triangle_mesh()
   mesh.compute_vertex_normals()
-  mesh_filepath = join(req.results_directory, "integrated.ply")
-  o3d.io.write_triangle_mesh(mesh_filepath, mesh, False, True)
+  mesh_filepath = ""
+  if (req.results_directory != ""):
+    mesh_filepath = join(req.results_directory, "integrated.ply")
+    o3d.io.write_triangle_mesh(mesh_filepath, mesh, False, True)
   mesh_msg = meshToRos(mesh)
   mesh_msg.header.stamp = rospy.get_rostime()
   mesh_msg.header.frame_id = relative_frame
   mesh_pub.publish(mesh_msg)
+
   print("Mesh Generated")
 
   if (req.archive_directory != ""):
@@ -149,7 +152,10 @@ def stopYakReconstructionCallback(req):
     archive_mesh_filepath = join(req.archive_directory, "integrated.ply")
     o3d.io.write_triangle_mesh(archive_mesh_filepath, mesh, False, True)
 
-  return StopYakReconstructionResponse(True, mesh_filepath)
+  if not req.return_mesh_marker:
+    mesh_msg = Marker()
+
+  return StopYakReconstructionResponse(True, mesh_filepath, mesh_msg);
 
 
 def cameraCallback(depth_image_msg, rgb_image_msg):

--- a/src/open3d_interface/yak/__init__.py
+++ b/src/open3d_interface/yak/__init__.py
@@ -269,9 +269,9 @@ def main():
 
   rospy.Timer(rospy.Duration(0.5), timerReconstruction)
 
-  mesh_pub = rospy.Publisher("open3d_mesh", Marker, queue_size=10)
+  mesh_pub = rospy.Publisher("~open3d_mesh", Marker, queue_size=10)
 
-  start_server = rospy.Service('start_reconstruction', StartYakReconstruction, startYakReconstructionCallback)
-  stop_server = rospy.Service('stop_reconstruction', StopYakReconstruction, stopYakReconstructionCallback)
+  start_server = rospy.Service('~start_reconstruction', StartYakReconstruction, startYakReconstructionCallback)
+  stop_server = rospy.Service('~stop_reconstruction', StopYakReconstruction, stopYakReconstructionCallback)
 
   rospy.spin()

--- a/srv/RunReconstructionSystem.srv
+++ b/srv/RunReconstructionSystem.srv
@@ -6,7 +6,7 @@ bool debug_mode # false
 
 # Stages to run
 bool make      # Step 1) make fragments from RGBD sequence
-bool register  # Step 2) register all fragments to detect loop closure"
+bool register_fragments  # Step 2) register all fragments to detect loop closure"
 bool refine    # Step 3) refine rough registrations
 bool integrate # Step 4) integrate the whole RGBD sequence to make final mesh
 

--- a/srv/StopYakReconstruction.srv
+++ b/srv/StopYakReconstruction.srv
@@ -1,5 +1,7 @@
 string archive_directory # If not empty it will dump rgb, depth, poses and intrinsics to this directory
-string results_directory # The directory to save the generated mesh
+string results_directory  # If not empty, the generated mesh will be saved to this file
+bool return_mesh_marker  # If true, return the mesh as a marker too
 ---
 bool success
 string mesh_filepath # The filepath to the saved mesh
+visualization_msgs/Marker mesh_marker


### PR DESCRIPTION
Makes a couple of changes

1. Returns a mesh from the yak node as a marker if a bool is set
2. Add some namespaces to the interfaces so you can run multiple instances of the same node
3. Rename register in a ros message to register_fragments. Otherwise, C++ nodes that include this will get compilation errors since register is a keyword.
4. Add some try catches

I'll admit that this could probably use some cleanup. For example, we probably want to rename make to make_fragments to match. However, I wanted to get this PRed before it got lost.